### PR TITLE
Use fingerprint of key as resource name.

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -10,7 +10,7 @@ class hipchat::repo {
 			  include_src       => false,
 			}
 			
-			apt::key { 'hipchat':
+			apt::key { '0x69F57C04EA38EEE7A47E9BCCAAD4AA21729B5780':
 			  key_source => 'https://www.hipchat.com/keys/hipchat-linux.key',
 			}
 			


### PR DESCRIPTION
When trying to use rcoleman/hipchat in Puppet 4.2.2 I got the following error:

```
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: Evaluation Error: Error while evaluating a Function Call, validate_re(): "hipchat" does not match ["\\A(0x)?[0-9a-fA-F]{8}\\Z", "\\A(0x)?[0-9a-fA-F]{16}\\Z", "\\A(0x)?[0-9a-fA-F]{40}\\Z"] at /etc/puppetlabs/code/environments/hipchat/modules/apt/manifests/key.pp:51:3 on node diffie.sk.lan
```

Turns out the latest puppetlabs/apt repo does [some validation](https://github.com/puppetlabs/puppetlabs-apt/blob/master/manifests/key.pp#L51) and expects the resource name to be the id of the key.

Changing the resource name from hipchat to '0x729B5780' gave me the below warning so I went for the full 40 char fingerprint.

`Warning: /Apt_key[0x729B5780]: The id should be a full fingerprint (40 characters), see README.`

I'm not convinced that this behaviour in puppetlabs/apt isn't a bug - Let me know your thoughts!

Tested this in Puppet 4.2.2.
