### PR TITLE
Update package and apt source for hipchat4

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -6,8 +6,8 @@ class hipchat(
     require hipchat::repo
   }
   
-  package { 'hipchat':
-    ensure => installed,
+  package { 'hipchat4':
+    ensure => latest,
   }
 
 }

--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -4,14 +4,15 @@ class hipchat::repo {
     'Debian': {
       
       apt::source { 'hipchat':
-			  location          => 'http://downloads.hipchat.com/linux/apt',
-			  release           => 'stable',
+			  location          => 'https://atlassian.artifactoryonline.com/atlassian/hipchat-apt-client',
+			  release           => "$lsbdistcodename",
 			  repos             => 'main',
-			  include_src       => false,
+			  include           => { 'src' => false },
 			}
 			
 			apt::key { 'hipchat':
-			  key_source => 'https://www.hipchat.com/keys/hipchat-linux.key',
+			  id     => 'FD1ACC751D0106938C1E6B33EBA59E53CC64091D',
+			  source => 'https://atlassian.artifactoryonline.com/atlassian/api/gpg/key/public',
 			}
 			
     }


### PR DESCRIPTION
This commit updates the package name, the apt source, and adds the
atlassian signing key to install hipchat4.

See the [hipchat downloads page](https://www.hipchat.com/downloads#linux)
for more details about installation on Debian based systems.
